### PR TITLE
Add "Contact" page with central links to Matrix and Discord

### DIFF
--- a/docs/config/development/pack-from-scratch/index.rst
+++ b/docs/config/development/pack-from-scratch/index.rst
@@ -366,7 +366,7 @@ If for whatever reason your pack does not load, an error message will show up in
 has failed to load, please read through any of these errors and try to interpret what you may have done wrong,
 and follow through the previous steps again carefully.
 
-If you still are unable to load the pack, feel free to provide any relevant errors in our `Discord server <https://discord.com/invite/PXUEbbF>`_.
+If you still are unable to load the pack, feel free to :doc:`contact us </contact>` with any relevant errors.
 
 Conclusion
 ==========

--- a/docs/config/development/samplers/index.rst
+++ b/docs/config/development/samplers/index.rst
@@ -807,4 +807,4 @@ Now that you've got an idea of `what noise is <#what-is-noise>`_, `how it works 
 `configuring it <#configuring-samplers>`_, you should now be equipped with the necessary  knowledge to start configuring
 your own fancy samplers for use in your own customized world generation! For more information on the available
 samplers in Terra, please refer to the :doc:`/config/documentation/sampler/index` page. If you have any
-further questions, feel free to ask us in our `Discord <https://discord.gg/PXUEbbF>`_!
+further questions, feel free to :doc:`ask for help </contact>`!

--- a/docs/contact.rst
+++ b/docs/contact.rst
@@ -1,8 +1,9 @@
-===================
-Contact/Get Support
-===================
+=================
+Contact & Support
+=================
 
-You can contact the Terra team for questions, support, or contributions, on the following platforms:
+You can contact the Terra team for questions, support, or contributions on the following platforms:
 
 * `Matrix <https://matrix.to/#/#polydev:dfsek.com>`_
 * `Discord <https://discord.gg/PXUEbbF>`_ (bridged to Matrix)
+

--- a/docs/contact.rst
+++ b/docs/contact.rst
@@ -1,0 +1,19 @@
+===================
+Contact/Get Support
+===================
+
+You can contact the Terra team for questions, support, or contributions, on the following platforms:
+
+* `Matrix <https://matrix.to/#/#polydev:dfsek.com>`_
+* `Discord <https://discord.gg/PXUEbbF>`_ (bridged to Matrix)
+
+Contents
+========
+
+.. toctree::
+    :maxdepth: 3
+    :titlesonly:
+
+    install/index
+    config/index
+    api/index

--- a/docs/contact.rst
+++ b/docs/contact.rst
@@ -6,14 +6,3 @@ You can contact the Terra team for questions, support, or contributions, on the 
 
 * `Matrix <https://matrix.to/#/#polydev:dfsek.com>`_
 * `Discord <https://discord.gg/PXUEbbF>`_ (bridged to Matrix)
-
-Contents
-========
-
-.. toctree::
-    :maxdepth: 3
-    :titlesonly:
-
-    install/index
-    config/index
-    api/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ Contents
     :maxdepth: 3
     :titlesonly:
 
+    contact
     install/index
     config/index
     api/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Contents
     :maxdepth: 3
     :titlesonly:
 
-    contact
     install/index
+    contact
     config/index
     api/index

--- a/docs/install/bukkit-server-world-creation.rst
+++ b/docs/install/bukkit-server-world-creation.rst
@@ -123,5 +123,5 @@ If you run into issues during the world set up process, be sure to check you hav
 Check for any errors in your server console/logs and try to interpret what the issue might be.
 
 If you are unable to set up a world successfully, and have attempted to fix any issues yourself,
-please feel free to shoot us a message on our Discord server and provide any relevant information and most importantly the before mentioned logs!
+please feel free to :doc:`ask for help </contact>` and provide any relevant information and most importantly the before mentioned logs!
 

--- a/docs/install/mod-client-world-creation.rst
+++ b/docs/install/mod-client-world-creation.rst
@@ -31,4 +31,4 @@ If you run into issues during the world set up process, be sure to check you hav
 Check for any errors in your client logs and try to interpret what the issue might be.
 
 If you are unable to set up a world successfully, and have attempted to fix any issues yourself,
-please feel free to shoot us a message on our Discord server and provide any relevant information and most importantly the before mentioned logs!
+please feel free to :doc:`ask for help </contact>` and provide any relevant information and most importantly the before mentioned logs!

--- a/docs/install/mod-server-world-creation.rst
+++ b/docs/install/mod-server-world-creation.rst
@@ -63,5 +63,5 @@ If you run into issues during the world set up process, be sure to check you hav
 Check for any errors in your server logs and try to interpret what the issue might be.
 
 If you are unable to set up a world successfully, and have attempted to fix any issues yourself,
-please feel free to shoot us a message on our Discord server and provide any relevant information and most importantly the before mentioned logs!
+please feel free to :doc:`ask for help </contact>` and provide any relevant information and most importantly the before mentioned logs!
 

--- a/docs/install/worldmanager-bukkit-world-creation.rst
+++ b/docs/install/worldmanager-bukkit-world-creation.rst
@@ -5,7 +5,7 @@ Worldmanager World Creation
 Most world managers will have their own methods of setting / changing the generator for a world, however some may not
 support the use of custom generators. Please refer to either the documentation or support for your preferred manager if
 you're not sure whether custom generators are supported, or how to set up a world with said manager, before consulting
-the Terra discord.
+the Terra support channels.
 
 Since there are many different plugins with their own process we won't be covering all of them, however we do recommend
 using `Multiverse Core <https://github.com/Multiverse/Multiverse-Core/wiki/>`_ if you are unsure which manager to use.
@@ -41,5 +41,5 @@ If you run into issues during the world set up process, be sure to check you hav
 Check for any errors in your server console/logs and try to interpret what the issue might be.
 
 If you are unable to set up a world successfully, and have attempted to fix any issues yourself,
-please feel free to shoot us a message on our Discord server and provide any relevant information and most importantly the before mentioned logs!
+please feel free to :doc:`ask for help </contact>` and provide any relevant information and most importantly the before mentioned logs!
 


### PR DESCRIPTION
We can also (probably?) link to this page from the "Discord" section on Modrinth.