### PR TITLE
Add LocalNoiseLookup description to sampler documentation

### DIFF
--- a/docs/config/documentation/sampler/index.rst
+++ b/docs/config/documentation/sampler/index.rst
@@ -303,6 +303,7 @@ Definitions:
 Types:
 
 - ``NoiseLookup`` - Passes ``c`` into a sampler, and returns the output.
+- ``LocalNoiseLookup`` - Passes ``s - c`` into a sampler, and returns the output.
 - ``CellValue`` - Returns a random value based on ``c`` (Equivalent to ``NoiseLookup`` with a `WHITE_NOISE`_ sampler).
 - ``Angle`` - Returns the angle from ``s`` to ``c``.
 - ``Distance`` - Returns ``d1``.


### PR DESCRIPTION
Not much to add here. Since the change has been merged to terra and is included in the 6.4 release, I think it should also be included in the docs.