### PR TITLE
Fix 1.18 latest versions

### DIFF
--- a/docs/install/versions.yml
+++ b/docs/install/versions.yml
@@ -19,9 +19,9 @@ Fabric:
       stage: BETA
       link: https://modrinth.com/plugin/terra/version/6.3.0-BETA-fabric/
     - mc-ver: "1.18"
-      terra-ver: "6.1.1"
+      terra-ver: "6.0.0"
       stage: BETA
-      link: https://modrinth.com/mod/terra/version/6.1.1-BETA/
+      link: https://modrinth.com/plugin/terra/version/6.0.0-BETA
     - mc-ver: "1.17"
       terra-ver: "5.4.1"
       stage: BETA

--- a/docs/install/versions.yml
+++ b/docs/install/versions.yml
@@ -53,9 +53,9 @@ Bukkit:
       stage: BETA
       link: https://modrinth.com/mod/terra/version/6.3.0-BETA-bukkit
     - mc-ver: "1.18"
-      terra-ver: "6.1.2"
+      terra-ver: "6.0.0"
       stage: BETA
-      link: https://www.spigotmc.org/resources/terra.85151/download?version=456104/
+      link: https://www.spigotmc.org/resources/terra.85151/download?version=454311
     - mc-ver: "1.17"
       terra-ver: "5.4.1"
       stage: BETA


### PR DESCRIPTION
Minor correction to `versions.yml` changing the latest version compatible with 1.18 versions of Minecraft to 6.0.0-BETA. 6.1.1-BETA does not run on a fresh install of Fabric 1.18.2. The Spigot version was not tested, but assumed to be the same case and was edited accordingly.

Not entirely sure that this builds because I couldn't get it to run on my computer without commenting out some Python code, so ¯\_(ツ)_/¯

Fixes PolyhedralDev/Terra#384.