### PR TITLE
Add EXPRESSION Salted documentation

### DIFF
--- a/docs/config/documentation/addons/config-noise-function.yml
+++ b/docs/config/documentation/addons/config-noise-function.yml
@@ -795,7 +795,7 @@ config-noise-function:
                   the coordinates ``X = 2`` and ``Z = 5`` and ``salt = 3`` (the specified salt is additive
                   to any already configured salt, in this case ``2 + 1 = 3``).
                   
-                  The ``<sampler-name>Salted function is automatically generated for each sampler with the salt 
+                  The ``<sampler-name>Salted`` function is automatically generated for each sampler with the salt 
                   added as the last parameter of the sampler call. This also works for samplers contained within 
                   other samplers, e.g. nested `EXPRESSION`_ or `DOMAIN_WARP`_ samplers.
 

--- a/docs/config/documentation/addons/config-noise-function.yml
+++ b/docs/config/documentation/addons/config-noise-function.yml
@@ -777,6 +777,28 @@ config-noise-function:
                   The sampler above will output the result of a 2D `WHITE_NOISE`_ sampler when passed
                   the coordinates ``X = 2`` and ``Z = 5``.
 
+              .. card:: **Salting samplers**
+
+                  .. code-block:: yaml
+
+                      type: EXPRESSION
+
+                      samplers:
+                        whiteNoise:
+                          dimensions: 2
+                          type: WHITE_NOISE
+                          salt: 2
+
+                      expression: whiteNoiseSalted(2, 5, 1)
+
+                  The sampler above will output the result of a 2D `WHITE_NOISE`_ sampler when passed
+                  the coordinates ``X = 2`` and ``Z = 5`` and ``salt = 3`` (the specified salt is additive
+                  to any already configured salt, in this case ``2 + 1 = 3``).
+                  
+                  The ``<sampler-name>Salted function is automatically generated for each sampler with the salt 
+                  added as the last parameter of the sampler call. This also works for samplers contained within 
+                  other samplers, e.g. nested `EXPRESSION`_ or `DOMAIN_WARP`_ samplers.
+
               .. card:: **Combining everything**
 
                   .. code-block:: yaml


### PR DESCRIPTION
I did my best to parse the custom config format and added an example for how to use the Salted functionality of EXPRESSION samplers. Please double check my syntax and truthfulness of statements before merging. I did test whether the behavior is additive to already specified salts, and this appears to be case in the example I did. 