### PR TITLE
Fix dead links

### DIFF
--- a/docs/config/development/config-files.rst
+++ b/docs/config/development/config-files.rst
@@ -6,8 +6,8 @@ The majority of config development involves creating and manipulating
 `configuration
 files <https://en.wikipedia.org/wiki/Configuration_file>`__. *In the
 context of config development*, configuration files (or simply
-*configs*) are files contained within a `config pack <./Config-Packs>`__
-that define data that Terra uses to determine how worlds generate.
+*configs*) are files contained within a config pack that define data
+that Terra uses to determine how worlds generate.
 
 File Formats
 ============
@@ -20,9 +20,9 @@ XML, and YAML.
 In Terra the file formats used in config packs are flexible, as the
 functionality for reading and parsing different formats is provided via
 addons - this allows flexibility for developers to use whatever format
-they're most comfortable in. Files contained inside a `config
-pack <./Config-Packs>`__ will only attempt to load as configuration
-files if a **language addon** is installed that supports the file type.
+they're most comfortable in. Files contained inside a config pack will
+only attempt to load as configuration files if a **language addon** is
+installed that supports the file type.
 
 YAML
 ----

--- a/docs/config/development/pack-from-scratch/ores.rst
+++ b/docs/config/development/pack-from-scratch/ores.rst
@@ -29,7 +29,7 @@ Setting up Ores
 
     Add the ``config-ore`` addon as a dependency, using versions ``1.+``.
 
-    This addon will allow us to create palette config files.
+    This addon will allow us to create ore config files.
 
     .. code-block:: yaml
         :caption: pack.yml

--- a/docs/config/development/pack-from-scratch/trees.rst
+++ b/docs/config/development/pack-from-scratch/trees.rst
@@ -90,7 +90,7 @@ Setting up a New Structure
 
                 ``oak_tree.schem`` will be the example file name used for this guide.
 
-                A sample ``oak_tree.schem`` can be found on `GitHub <https://github.com/PolyhedralDev/TerraPackFromScratch/tree/master/4-adding-trees>`_ if needed.
+                A sample ``oak_tree.schem`` can be found on `GitHub <https://github.com/PolyhedralDev/TerraPackFromScratch/blob/master/5-adding-trees/oak_tree.schem>`_ if needed.
 
 .. warning::
 

--- a/docs/install/versions.yml
+++ b/docs/install/versions.yml
@@ -21,7 +21,7 @@ Fabric:
     - mc-ver: "1.20.4"
       terra-ver: "6.4.3"
       stage: BETA
-      link: https://modrinth.com/plugin/terra/version/6.4.3-BETA-fabric
+      link: https://modrinth.com/plugin/terra/version/6.6.0-BETA-fabirc
     - mc-ver: "1.20"
       terra-ver: "6.3.1"
       stage: BETA


### PR DESCRIPTION
* Remove links to config packs page as it no longer exists (fixes #50)
* Fix incorrect 'palette' reference in ores page (fixes #51)
* Fix link to 6.6.0 BETA fabric version in versions.yml (misspelled when uploaded to modrinth)
* Replace link in trees page to go to the correct folder + link to schem file directly